### PR TITLE
fix: AppointmentRequest @Future 검증 제거

### DIFF
--- a/lupin/src/main/java/com/example/demo/dto/request/AppointmentRequest.java
+++ b/lupin/src/main/java/com/example/demo/dto/request/AppointmentRequest.java
@@ -1,6 +1,5 @@
 package com.example.demo.dto.request;
 
-import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -19,6 +18,5 @@ public class AppointmentRequest {
     private Long doctorId;
 
     @NotNull(message = "예약 날짜는 필수입니다.")
-    @Future(message = "예약 날짜는 현재 시간보다 빨라야 합니다.")
     private LocalDateTime date;
 }


### PR DESCRIPTION
- @Future 검증이 예약 생성을 과도하게 제한하여 500 에러 발생
- 날짜 검증은 프론트엔드에서 충분히 처리됨