### PR TITLE
fix: AppointmentController @RequestMapping 경로 추가 (/api/appointment)

### DIFF
--- a/lupin/src/main/java/com/example/demo/controller/AppointmentController.java
+++ b/lupin/src/main/java/com/example/demo/controller/AppointmentController.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping()
+@RequestMapping("/api/appointment")
 public class AppointmentController {
 
     private final  AppointmentService appointmentService;


### PR DESCRIPTION
- 프론트엔드가 /api/appointment로 요청하는데 컨트롤러 매핑이 누락되어 있었음
- @RequestMapping()을 @RequestMapping("/api/appointment")로 수정