### PR TITLE
feat: 의사 목록 조회 API 구현

### DIFF
--- a/lupin/src/main/java/com/example/demo/controller/DoctorController.java
+++ b/lupin/src/main/java/com/example/demo/controller/DoctorController.java
@@ -1,0 +1,50 @@
+package com.example.demo.controller;
+
+import com.example.demo.dto.response.DoctorResponse;
+import com.example.demo.service.DoctorService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/doctors")
+public class DoctorController {
+
+    private final DoctorService doctorService;
+
+    /**
+     * 모든 의사 목록 조회
+     * 또는 진료과별 의사 목록 조회 (specialty 파라미터 있을 경우)
+     */
+    @GetMapping
+    public ResponseEntity<List<DoctorResponse>> getDoctors(
+            @RequestParam(required = false) String specialty
+    ) {
+        List<DoctorResponse> doctors;
+
+        if (specialty != null && !specialty.isEmpty()) {
+            log.info("진료과별 의사 목록 조회: {}", specialty);
+            doctors = doctorService.getDoctorsBySpecialty(specialty);
+        } else {
+            log.info("전체 의사 목록 조회");
+            doctors = doctorService.getAllDoctors();
+        }
+
+        return ResponseEntity.ok(doctors);
+    }
+
+    /**
+     * 의사 ID로 상세 정보 조회
+     */
+    @GetMapping("/{doctorId}")
+    public ResponseEntity<DoctorResponse> getDoctorById(@PathVariable Long doctorId) {
+        log.info("의사 상세 정보 조회: {}", doctorId);
+        DoctorResponse doctor = doctorService.getDoctorById(doctorId);
+        return ResponseEntity.ok(doctor);
+    }
+}

--- a/lupin/src/main/java/com/example/demo/domain/entity/DoctorProfile.java
+++ b/lupin/src/main/java/com/example/demo/domain/entity/DoctorProfile.java
@@ -1,0 +1,62 @@
+package com.example.demo.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "doctor_profiles")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class DoctorProfile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(length = 100)
+    private String specialty; // 전공 (내과, 외과, 정형외과 등)
+
+    @Column(name = "license_number", length = 50)
+    private String licenseNumber; // 의사 면허번호
+
+    @Column(name = "medical_experience")
+    private Integer medicalExperience; // 경력 (년)
+
+    @Column(length = 20)
+    private String phone; // 연락처
+
+    @Column(name = "birth_date")
+    private LocalDate birthDate; // 생년월일
+
+    @Column(length = 10)
+    private String gender; // 성별
+
+    @Column(length = 500)
+    private String address; // 주소
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/lupin/src/main/java/com/example/demo/dto/response/DoctorResponse.java
+++ b/lupin/src/main/java/com/example/demo/dto/response/DoctorResponse.java
@@ -1,0 +1,42 @@
+package com.example.demo.dto.response;
+
+import com.example.demo.domain.entity.DoctorProfile;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DoctorResponse {
+
+    private Long id; // User ID
+    private String userId; // 로그인 ID
+    private String name; // 의사 이름
+    private String specialty; // 전공 (내과, 외과 등)
+    private String licenseNumber; // 면허번호
+    private Integer medicalExperience; // 경력 (년)
+    private String phone; // 연락처
+    private LocalDate birthDate; // 생년월일
+    private String gender; // 성별
+    private String address; // 주소
+
+    public static DoctorResponse from(DoctorProfile doctorProfile) {
+        return DoctorResponse.builder()
+                .id(doctorProfile.getUser().getId())
+                .userId(doctorProfile.getUser().getUserId())
+                .name(doctorProfile.getUser().getName())
+                .specialty(doctorProfile.getSpecialty())
+                .licenseNumber(doctorProfile.getLicenseNumber())
+                .medicalExperience(doctorProfile.getMedicalExperience())
+                .phone(doctorProfile.getPhone())
+                .birthDate(doctorProfile.getBirthDate())
+                .gender(doctorProfile.getGender())
+                .address(doctorProfile.getAddress())
+                .build();
+    }
+}

--- a/lupin/src/main/java/com/example/demo/repository/DoctorProfileRepository.java
+++ b/lupin/src/main/java/com/example/demo/repository/DoctorProfileRepository.java
@@ -1,0 +1,36 @@
+package com.example.demo.repository;
+
+import com.example.demo.domain.entity.DoctorProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface DoctorProfileRepository extends JpaRepository<DoctorProfile, Long> {
+
+    /**
+     * User ID로 의사 프로필 조회
+     */
+    Optional<DoctorProfile> findByUserId(Long userId);
+
+    /**
+     * 전공(specialty)으로 의사 프로필 목록 조회
+     */
+    List<DoctorProfile> findBySpecialty(String specialty);
+
+    /**
+     * 모든 의사 프로필 조회 (User 정보 포함)
+     */
+    @Query("SELECT dp FROM DoctorProfile dp JOIN FETCH dp.user")
+    List<DoctorProfile> findAllWithUser();
+
+    /**
+     * 전공별 의사 프로필 조회 (User 정보 포함)
+     */
+    @Query("SELECT dp FROM DoctorProfile dp JOIN FETCH dp.user WHERE dp.specialty = :specialty")
+    List<DoctorProfile> findBySpecialtyWithUser(@Param("specialty") String specialty);
+}

--- a/lupin/src/main/java/com/example/demo/service/DoctorService.java
+++ b/lupin/src/main/java/com/example/demo/service/DoctorService.java
@@ -1,0 +1,52 @@
+package com.example.demo.service;
+
+import com.example.demo.domain.entity.DoctorProfile;
+import com.example.demo.dto.response.DoctorResponse;
+import com.example.demo.exception.BusinessException;
+import com.example.demo.exception.ErrorCode;
+import com.example.demo.repository.DoctorProfileRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DoctorService {
+
+    private final DoctorProfileRepository doctorProfileRepository;
+
+    /**
+     * 모든 의사 목록 조회
+     */
+    public List<DoctorResponse> getAllDoctors() {
+        List<DoctorProfile> doctorProfiles = doctorProfileRepository.findAllWithUser();
+        return doctorProfiles.stream()
+                .map(DoctorResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 진료과별 의사 목록 조회
+     */
+    public List<DoctorResponse> getDoctorsBySpecialty(String specialty) {
+        List<DoctorProfile> doctorProfiles = doctorProfileRepository.findBySpecialtyWithUser(specialty);
+        return doctorProfiles.stream()
+                .map(DoctorResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 의사 ID로 상세 정보 조회
+     */
+    public DoctorResponse getDoctorById(Long userId) {
+        DoctorProfile doctorProfile = doctorProfileRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND, "존재하지 않는 의사입니다."));
+        return DoctorResponse.from(doctorProfile);
+    }
+}


### PR DESCRIPTION
- DoctorProfile 엔티티 생성 (doctor_profiles 테이블 매핑)
- DoctorProfileRepository 생성 (specialty별 조회 지원)
- DoctorService 생성 (전체/진료과별 의사 목록 조회)
- DoctorController 생성
  - GET /api/doctors - 전체 의사 목록
  - GET /api/doctors?specialty=내과 - 진료과별 의사 목록
  - GET /api/doctors/{id} - 의사 상세 정보
- DoctorResponse DTO 생성