### PR TITLE
fix: Medical.tsx roomId 형식 수정

### DIFF
--- a/lupin/src/components/dashboard/medical/Medical.tsx
+++ b/lupin/src/components/dashboard/medical/Medical.tsx
@@ -225,7 +225,7 @@ MedicalProps) {
 
   // WebSocket 연결 (예약이 있을 때만)
   const roomId = activeAppointment
-    ? `${currentPatientId}:${activeAppointment.doctorId}`
+    ? `appointment_${activeAppointment.id}`
     : "";
 
   // 메시지 수신 콜백 (HEAD의 로직 유지: 본인이 보낸 메시지는 알림 표시 안함)


### PR DESCRIPTION
- roomId 형식을 '환자ID:의사ID'에서 'appointment_예약ID'로 변경
- 백엔드 ChatService와 일치하는 형식 사용
- 의사-환자 간 메시지 매칭 문제 해결