### PR TITLE
fix: 채팅방 선택 로직 개선 및 의사 이름 통일

### DIFF
--- a/lupin/src/components/dashboard/chat/DoctorChatPage.tsx
+++ b/lupin/src/components/dashboard/chat/DoctorChatPage.tsx
@@ -296,7 +296,10 @@ export default function DoctorChatPage() {
                         <div
                           key={room.roomId}
                           onClick={() => {
-                            // 채팅방 전환 시 이전 메시지 초기화
+                            // 이미 선택된 채팅방이면 아무 작업도 하지 않음
+                            if (isSelected) return;
+
+                            // 다른 채팅방으로 전환 시 이전 메시지 초기화
                             setMessages([]);
                             setSelectedChatMember({
                               id: room.patientId,

--- a/lupin/src/components/dashboard/medical/Medical.tsx
+++ b/lupin/src/components/dashboard/medical/Medical.tsx
@@ -311,7 +311,7 @@ MedicalProps) {
       id: 3,
       name: "진통제 처방",
       date: "10월 15일",
-      doctor: "김의사",
+      doctor: "김준호 의사",
       medicines: ["이부프로펜 200mg"],
       diagnosis: "근육통",
       instructions: "통증이 있을 때 4-6시간 간격으로 복용하세요.",
@@ -331,7 +331,7 @@ MedicalProps) {
     {
       id: 1,
       type: "내과 상담",
-      doctor: "김의사",
+      doctor: "김준호 의사",
       date: "11월 15일",
       time: "오후 3시",
       status: "예정",
@@ -489,11 +489,13 @@ MedicalProps) {
                     <div className="flex items-center gap-3">
                       <Avatar className="w-10 h-10">
                         <AvatarFallback className="bg-gradient-to-br from-blue-600 to-blue-800 text-white font-black">
-                          김
+                          {activeAppointment?.doctorName?.charAt(0) || "의"}
                         </AvatarFallback>
                       </Avatar>
                       <div>
-                        <div className="font-bold text-gray-900">김의사</div>
+                        <div className="font-bold text-gray-900">
+                          {activeAppointment?.doctorName || "알 수 없음"} 의사
+                        </div>
                         <div className="text-xs text-gray-600">온라인</div>
                       </div>
                     </div>


### PR DESCRIPTION
문제점:
1. 같은 채팅방 재클릭 시 메시지가 초기화되어 빈 화면이 됨
2. 다른 채팅방으로 전환이 제대로 작동하지 않음
3. 의사 이름 불일치 - '김의사' vs '김준호'

해결방법:
1. 이미 선택된 채팅방 클릭 시 early return
   - if (isSelected) return; 추가
   - 불필요한 상태 업데이트 방지

2. 선택되지 않은 채팅방만 전환 로직 실행
   - setMessages([]) 및 setSelectedChatMember 호출
   - useEffect 의존성이 제대로 감지하도록 보장

3. 의사 이름 형식 통일: '{이름} 의사'
   - Medical.tsx: activeAppointment.doctorName 사용
   - 동적으로 '{doctorName} 의사' 표시
   - 더미 데이터: '김의사' → '김준호 의사'

개선사항:
- 채팅방 UX 개선 (선택된 채팅방은 반응 없음)
- 의사 이름 일관성 확보
- 불필요한 리렌더링 방지