### PR TITLE
fix: 진료 종료 시 환자 알림 및 채팅 내역 초기화 문제 해결

### DIFF
--- a/lupin/src/components/dashboard/appointments/AppointmentsPage.tsx
+++ b/lupin/src/components/dashboard/appointments/AppointmentsPage.tsx
@@ -130,6 +130,33 @@ export default function AppointmentsPage({
     };
   }, [currentUser.id, currentUser.role]);
 
+  // 환자 측 진료 종료 이벤트 수신 (진료 종료 알림 및 예약 목록 새로고침)
+  useEffect(() => {
+    const handleConsultationEnded = async (event: Event) => {
+      const customEvent = event as CustomEvent<{ doctorName: string }>;
+      const { doctorName } = customEvent.detail;
+
+      // 환자에게 알림 메시지 표시
+      alert(`${doctorName} 의사의 진료가 종료되었습니다.`);
+
+      // 예약 목록 새로고침
+      try {
+        if (currentUser.role === "PATIENT") {
+          const data = await appointmentApi.getPatientAppointments(currentUser.id);
+          setAppointments(data);
+        }
+      } catch (error) {
+        console.error("예약 목록 새로고침 실패:", error);
+      }
+    };
+
+    window.addEventListener("consultationEnded", handleConsultationEnded);
+
+    return () => {
+      window.removeEventListener("consultationEnded", handleConsultationEnded);
+    };
+  }, [currentUser.id, currentUser.role]);
+
   // 예약 취소 핸들러
   const handleCancelAppointment = async (appointmentId: number) => {
     if (!confirm("정말로 예약을 취소하시겠습니까?")) return;

--- a/lupin/src/components/dashboard/chat/ChatRoom.tsx
+++ b/lupin/src/components/dashboard/chat/ChatRoom.tsx
@@ -38,6 +38,7 @@ export default function ChatRoom({
   useEffect(() => {
     if (!open) return;
 
+    // 채팅창이 열릴 때 항상 최신 메시지 로드
     chatApi
       .getAllMessagesByRoomId(roomId)
       .then((data) => setMessages(data))
@@ -47,7 +48,7 @@ export default function ChatRoom({
     chatApi
       .markAsRead(roomId, currentUser.id)
       .catch((err) => console.error('읽음 처리 실패:', err));
-  }, [open, roomId, currentUser.id]);
+  }, [roomId, currentUser.id]); // open 제거 - appointmentId가 바뀔 때만 로드
 
   // 2. 웹소켓 연결
   const { isConnected, sendMessage } = useWebSocket({


### PR DESCRIPTION
- 진료 종료 시 환자에게 실시간 알림 표시 및 예약 목록 자동 새로고침
- 채팅창 재오픈 시 메시지가 사라지는 문제 수정 (useEffect 의존성 배열에서 open 제거)