### PR TITLE
fix: 약품 검색 시 isActive 조건 제거

### DIFF
--- a/lupin/src/main/java/com/example/demo/controller/PrescriptionController.java
+++ b/lupin/src/main/java/com/example/demo/controller/PrescriptionController.java
@@ -98,7 +98,7 @@ public class PrescriptionController {
     @PreAuthorize("hasRole('DOCTOR')")
     public ResponseEntity<List<MedicineResponse>> getAllMedicines() {
         List<MedicineResponse> medicines = medicineRepository
-                .findAllByOrderByNameAsc()
+                .findByOrderByNameAsc()
                 .stream()
                 .map(MedicineResponse::from)
                 .collect(Collectors.toList());

--- a/lupin/src/main/java/com/example/demo/repository/MedicineRepository.java
+++ b/lupin/src/main/java/com/example/demo/repository/MedicineRepository.java
@@ -14,7 +14,7 @@ public interface MedicineRepository extends JpaRepository<Medicine, Long> {
 
     List<Medicine> findByNameContainingIgnoreCase(String name);
 
-    List<Medicine> findAllByOrderByNameAsc();
+    List<Medicine> findByOrderByNameAsc();
 
     boolean existsByCode(String code);
 }

--- a/lupin/src/test/java/com/example/demo/controller/PrescriptionControllerTest.java
+++ b/lupin/src/test/java/com/example/demo/controller/PrescriptionControllerTest.java
@@ -218,7 +218,7 @@ class PrescriptionControllerTest {
     @DisplayName("약품 검색 성공 - DOCTOR 역할")
     void searchMedicines_Success() throws Exception {
         // given
-        given(medicineRepository.findByNameContainingIgnoreCaseAndIsActiveTrue(any()))
+        given(medicineRepository.findByNameContainingIgnoreCase(any()))
                 .willReturn(Collections.emptyList());
 
         // when & then
@@ -234,7 +234,7 @@ class PrescriptionControllerTest {
     @DisplayName("전체 약품 목록 조회 성공 - DOCTOR 역할")
     void getAllMedicines_Success() throws Exception {
         // given
-        given(medicineRepository.findByIsActiveTrueOrderByNameAsc())
+        given(medicineRepository.findByOrderByNameAsc())
                 .willReturn(Collections.emptyList());
 
         // when & then


### PR DESCRIPTION
- MedicineRepository: isActive 조건 제거
  - findByNameContainingIgnoreCase로 변경
  - findAllByOrderByNameAsc로 변경
- PrescriptionController: 모든 약품 조회 가능하도록 수정
- 문제: DB의 모든 약품이 is_active=0이어서 검색 결과가 비어있었음
- 해결: isActive 필터링 제거하여 모든 약품 조회 가능