### PR TITLE
fix: 약품 검색 결과 표시 개선 및 처방전 목록 자동 새로고침

### DIFF
--- a/lupin/src/components/dashboard/chat/ChatRoom.tsx
+++ b/lupin/src/components/dashboard/chat/ChatRoom.tsx
@@ -269,6 +269,11 @@ export default function ChatRoom({
         onSuccess={() => {
           // 처방전 발급 성공 시 채팅으로 알림 메시지 전송
           sendMessage("처방전을 발급했습니다. 확인해주세요.", currentUser.id);
+
+          // 처방전 목록 새로고침 이벤트 발생 (환자 Medical 페이지용)
+          window.dispatchEvent(new CustomEvent("prescription-created", {
+            detail: { patientId: targetUser.id }
+          }));
         }}
       />
     </>

--- a/lupin/src/components/dashboard/chat/PrescriptionDialog.tsx
+++ b/lupin/src/components/dashboard/chat/PrescriptionDialog.tsx
@@ -263,9 +263,6 @@ export default function PrescriptionDialog({
                                     <div className="font-bold text-sm text-gray-900">
                                       {med.name}
                                     </div>
-                                    <div className="text-xs text-gray-600 mt-1">
-                                      {med.manufacturer} · {med.standardDosage}
-                                    </div>
                                     {med.description && (
                                       <div className="text-xs text-gray-500 mt-1">
                                         {med.description}

--- a/lupin/src/components/dashboard/medical/Medical.tsx
+++ b/lupin/src/components/dashboard/medical/Medical.tsx
@@ -580,6 +580,30 @@ export default function Medical({ setSelectedPrescription }: MedicalProps) {
     loadPrescriptions();
   }, [currentPatientId]);
 
+  // 처방전 발급 이벤트 처리 (처방전 목록 새로고침)
+  useEffect(() => {
+    const handlePrescriptionCreated = async (event: Event) => {
+      const customEvent = event as CustomEvent<{ patientId: number }>;
+      const { patientId } = customEvent.detail;
+
+      // 현재 환자의 처방전인 경우에만 새로고침
+      if (patientId === currentPatientId) {
+        try {
+          const data = await prescriptionApi.getPatientPrescriptions(currentPatientId);
+          setPrescriptions(data);
+        } catch {
+          setPrescriptions([]);
+        }
+      }
+    };
+
+    window.addEventListener("prescription-created", handlePrescriptionCreated);
+
+    return () => {
+      window.removeEventListener("prescription-created", handlePrescriptionCreated);
+    };
+  }, [currentPatientId]);
+
   // 알림에서 채팅방 자동 오픈 이벤트 처리
   useEffect(() => {
     const handleOpenAppointmentChat = async (event: Event) => {


### PR DESCRIPTION
1. 약품 검색 결과에서 불필요한 정보 제거
   - manufacturer, standardDosage 표시 제거
   - 약품명과 설명만 표시하도록 수정

2. 처방전 발급 후 환자 목록 자동 새로고침
   - ChatRoom: prescription-created 이벤트 발생
   - Medical: 이벤트 수신하여 처방전 목록 자동 새로고침
   - 환자가 새로고침 없이 바로 처방전 확인 가능