### PR TITLE
처방전 발급 시 Lazy Loading 문제 수정

### DIFF
--- a/lupin/src/main/java/com/example/demo/service/PrescriptionService.java
+++ b/lupin/src/main/java/com/example/demo/service/PrescriptionService.java
@@ -72,7 +72,7 @@ public class PrescriptionService {
 
     @Transactional
     public Prescription issuePrescription(Long appointmentId, Long doctorId, Long patientId, String diagnosis) {
-        Appointment appointment = appointmentRepository.findById(appointmentId)
+        Appointment appointment = appointmentRepository.findByIdWithPatientAndDoctor(appointmentId)
                 .orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다."));
 
         // 담당 의사 검증
@@ -117,7 +117,7 @@ public class PrescriptionService {
 
     @Transactional
     public PrescriptionResponse createPrescription(Long doctorId, PrescriptionRequest request) {
-        Appointment appointment = appointmentRepository.findById(request.getAppointmentId())
+        Appointment appointment = appointmentRepository.findByIdWithPatientAndDoctor(request.getAppointmentId())
                 .orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다."));
 
         // 담당 의사 검증


### PR DESCRIPTION
- findById() 대신 findByIdWithPatientAndDoctor() 사용
- Appointment 조회 시 Patient와 Doctor를 Eager Loading하여 LazyInitializationException 방지
- createPrescription 및 issuePrescription 메서드에 적용