### PR TITLE
issuePrescription 반환 타입을 PrescriptionResponse로 변경

### DIFF
--- a/lupin/src/main/java/com/example/demo/service/PrescriptionService.java
+++ b/lupin/src/main/java/com/example/demo/service/PrescriptionService.java
@@ -71,7 +71,7 @@ public class PrescriptionService {
     }
 
     @Transactional
-    public Prescription issuePrescription(Long appointmentId, Long doctorId, Long patientId, String diagnosis) {
+    public PrescriptionResponse issuePrescription(Long appointmentId, Long doctorId, Long patientId, String diagnosis) {
         Appointment appointment = appointmentRepository.findByIdWithPatientAndDoctor(appointmentId)
                 .orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다."));
 
@@ -112,7 +112,9 @@ public class PrescriptionService {
 
         appointment.complete();
 
-        return prescriptionRepository.save(prescription);
+        Prescription saved = prescriptionRepository.save(prescription);
+
+        return PrescriptionResponse.from(saved);
     }
 
     @Transactional

--- a/lupin/src/test/java/com/example/demo/service/PrescriptionServiceTest.java
+++ b/lupin/src/test/java/com/example/demo/service/PrescriptionServiceTest.java
@@ -215,13 +215,13 @@ class PrescriptionServiceTest {
                 .willReturn(newPrescription);
 
         // when
-        Prescription result = prescriptionService.issuePrescription(appointmentId, doctorId, patient.getId(), diagnosis);
+        var result = prescriptionService.issuePrescription(appointmentId, doctorId, patient.getId(), diagnosis);
 
         // then
         assertThat(result).isNotNull();
         assertThat(result.getDiagnosis()).isEqualTo(diagnosis);
-        assertThat(result.getDoctor()).isEqualTo(doctor);
-        assertThat(result.getPatient()).isEqualTo(patient);
+        assertThat(result.getDoctorName()).isEqualTo(doctor.getName());
+        assertThat(result.getPatientName()).isEqualTo(patient.getName());
     }
 
     @Test
@@ -259,11 +259,11 @@ class PrescriptionServiceTest {
                 .willReturn(savedPrescription);
 
         // when
-        Prescription result = prescriptionService.issuePrescription(appointmentId, doctorId, patient.getId(), diagnosis);
+        var result = prescriptionService.issuePrescription(appointmentId, doctorId, patient.getId(), diagnosis);
 
         // then
-        assertThat(result.getAppointment()).isNotNull();
-        assertThat(result.getAppointment().getId()).isEqualTo(appointmentId);
+        assertThat(result.getAppointmentId()).isNotNull();
+        assertThat(result.getAppointmentId()).isEqualTo(appointmentId);
     }
 
     @Test


### PR DESCRIPTION
- Lazy Loading으로 인한 Jackson 직렬화 문제 해결
- Entity 대신 DTO를 반환하여 JSON 변환 시 안전성 확보
- Prescription -> Doctor -> 처방전 리스트 순환 참조 방지
- 테스트 코드도 PrescriptionResponse 반환에 맞게 수정