### PR TITLE
fix: Prescription 생성 시 medicines 리스트 명시적 초기화

### DIFF
--- a/lupin/src/main/java/com/example/demo/service/PrescriptionService.java
+++ b/lupin/src/main/java/com/example/demo/service/PrescriptionService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -158,6 +159,7 @@ public class PrescriptionService {
                     .diagnosis(request.getDiagnosis())
                     .instructions(request.getAdditionalInstructions())
                     .date(LocalDate.now())
+                    .medicines(new ArrayList<>())
                     .build();
 
             // 6. 약품 추가


### PR DESCRIPTION
Lombok Builder 사용 시 @Builder.Default가 제대로 작동하지 않아
medicines 리스트가 null이 되는 문제 해결

변경사항:
- Prescription.builder()에 .medicines(new ArrayList<>()) 추가
- ArrayList import 추가